### PR TITLE
Update the Sniper Kit hullmod to match it's description

### DIFF
--- a/data/hullmods/hull_mods.csv
+++ b/data/hullmods/hull_mods.csv
@@ -6,10 +6,10 @@ Advanced Avionics,diableavionics_avionics,4,0.33,Diable Avionics,"no_build_in, r
 ,,,,,,,,,,,,,,,,,,,
 Resilient Frame,diableavionics_wanzer,,,,,,,,TRUE,,0,0,0,0,data.hullmods.DiableAvionicsWanzer,"Wanzers are exceptionally durable small crafts, with reinforced internals and tripe redundant systems. They get %s resistance to EMP, plus their weapons and engines are %s less likely to fail.",Gives Wanzers a %s resitance to EMP and reduce the damage taken to their weapons and engines by %s .,,graphics/da/hullmods/diableavionics_quantumsensor.png
 ,,,,,,,,,,,,,,,,,,,
-Sniper kit,diableavionics_sniperkit,2,,Diable Avionics,req_spaceport,Fighters,15000,,,,3,4,6,10,data.hullmods.DiableAvionicsSniperkit,"A special upgrade kit to uiltize the support ability of the Warlust wanzer fighter,this kit contains special ammo and next gen laser aim-sight for the DMR.
+Sniper kit,diableavionics_sniperkit,2,,Diable Avionics,req_spaceport,Fighters,15000,,,,3,4,6,10,data.hullmods.DiableAvionicsSniperkit,"A special upgrade kit to uiltize the support ability of the Warlust wanzer fighter, this kit contains special ammo and next gen laser aim-sight for the DMR.
 Comes equipped with a short range linked targeting core that allows the Warlust wanzer to increase their targeting range along with their carrier.
-All Warlust wanzer fighters carried by their respective carrier get same range bonus as its carrier(%s/%s/%s/%s,by hullsize), while making the Warlust's and any accompanying fighters engage range %s.","Turn warlust into ""Supporter wings"" role,and gain extra range.
- ",Only reduced %s Warlust`s engaging range instead of %s.,graphics/da/hullmods/dibaleavionics_sniperkit.png
+All Warlust wanzer fighters get bonus range (%s/%s/%s/%s, by carrier's size), while reducing the Warlust's and any accompanying fighter's engagement range by %s.","Turn warlust into ""Supporter wings"" role, and gain extra range.
+ ",Only reduces Warlust`s engagement range by %s instead of %s.,graphics/da/hullmods/dibaleavionics_sniperkit.png
 ,,,,,,,,,,,,,,,,,,,
 Cramped Hull,diableavionics_cramped,,,,,,,,TRUE,,0,0,0,0,data.hullmods.DiableAvionicsCramped,"This hull is abnormally small and can't accommodate any modification requiring much space such as %s, %s, or %s. Missile based weapons fire-rate reduced by %s.","Prevents the installation of large hullmods, reduce missiles fire-rate by %s.",,graphics/da/hullmods/diableavionics_cramped.png
 ,,,,,,,,,,,,,,,,,,,

--- a/data/hulls/wing_data.csv
+++ b/data/hulls/wing_data.csv
@@ -7,7 +7,7 @@ diableavionics_strife_wing,diableavionics_strife_Standard,"wanzer, fighter2, fig
 diableavionics_hoar_wing,diableavionics_hoar_akimbo,"wanzer, fighter3, fighter, high, diable_wanzer_bp, rare_bp, rd_no_extra_craft",1,,7,10,BOX,1000,500,200,2,INTERCEPTOR,Bodyguard,15,11500,,,,,,,,,,,,,4
 ,,,,,,,,,,,,,,,,,,,,,,,,,,,,
 ,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-diableavionics_warlust_wing,diableavionics_warlust_Standard,"wanzer, fighter3, fighter, high, diable_wanzer_bp, rare_bp, rd_no_extra_craft",2,,6,16,BOX,4000,500,,1,FIGHTER,Sniper,20,12000,,,,,,,,,,,,,5
+diableavionics_warlust_wing,diableavionics_warlust_Standard,"wanzer, fighter3, fighter, high, diable_wanzer_bp, rare_bp, rd_no_extra_craft",2,,6,16,BOX,4000,1000,,1,FIGHTER,Sniper,20,12000,,,,,,,,,,,,,5
 diableavionics_blizzaia_wing,diableavionics_blizzaia_Standard,"wanzer, bomber5, bomber, high, diable_wanzer_bp, rare_bp, rd_no_extra_craft",2,,11,18,V,4000,1000,-200,1,BOMBER,Grenadier,25,14000,,,,,,,,,,,,,13
 diableavionics_avalanche_wing,diableavionics_avalanche_variant,"wanzer, fighter3, fighter, high, diable_wanzer_bp, rare_bp, rd_no_extra_craft",2,,6,16,BOX,4000,450,,1,FIGHTER,Shock Trooper,20,12000,,,,,,,,,,,,,5
 ,,,,,,,,,,,,,,,,,,,,,,,,,,,,
@@ -20,12 +20,12 @@ diableavionics_zephyr_wing,diableavionics_zephyr_beam,"wanzer, fighter4, fighter
 diableavionics_vortex_wing,diableavionics_vortex_PD,"no_drop, no_sell, high",2,,4,0,V,2000,500,,1,SUPPORT,Drone,10,1500,,,,,,,,,,,,,18
 ,,,,,,,,,,,,,,,,,,,,,,,,,,,,
 ,,,,,,,,,,,,,,,,,,,,,,,,,,,,
-diableavionics_frost_wing_independent,diableavionics_frost_Standard,"restricted, independent_of_carrier, auto_fighter, no_drop, no_sell, fighter1, fighter, high, rd_no_extra_craft",4,2,6,1,CLAW,4000,500,,3,FIGHTER,Trooper,12,10000,,,,,,,,,,,,,1
-diableavionics_strife_wing_independent,diableavionics_strife_Standard,"restricted, independent_of_carrier, auto_fighter, no_drop, no_sell, fighter2, fighter, high, rd_no_extra_craft",4,2,7,1,BOX,4000,500,-100,2,FIGHTER,Gunner,14,11000,,,,,,,,,,,,,4
-diableavionics_hoar_wing_independent,diableavionics_hoar_akimbo,"restricted, independent_of_carrier, auto_fighter, no_drop, no_sell, fighter3, fighter, high, rd_no_extra_craft",4,2,7,1,BOX,1000,500,200,2,INTERCEPTOR,Bodyguard,13,11500,,,,,,,,,,,,,4
-diableavionics_warlust_wing_independent,diableavionics_warlust_Standard,"restricted, independent_of_carrier, auto_fighter, no_drop, no_sell, fighter3, fighter, high, rd_no_extra_craft",4,2,6,1,BOX,1000,500,,1,SUPPORT,Sniper,17,12000,,,,,,,,,,,,,5
-diableavionics_blizzaia_wing_independent,diableavionics_blizzaia_Standard,"restricted, independent_of_carrier, auto_fighter, no_drop, no_sell, bomber5, bomber, high, rd_no_extra_craft",4,2,11,1,V,4000,1000,-200,1,BOMBER,Grenadier,19,14000,,,,,,,,,,,,,13
-diableavionics_avalanche_wing_independent,diableavionics_avalanche_variant,"restricted, independent_of_carrier, auto_fighter, no_drop, no_sell, fighter3, fighter, high, rd_no_extra_craft",4,2,6,1,BOX,4000,500,,1,FIGHTER,Shock Trooper,15,12000,,,,,,,,,,,,,5
-diableavionics_valiant_wing_independent,diableavionics_valiant_Standard,"restricted, independent_of_carrier, auto_fighter, no_drop, no_sell, interceptor3, interceptor, high, rd_no_extra_craft",4,2,10,1,V,6000,500,-100,2,INTERCEPTOR,Commando,16,15000,,,,,,,,,,,,,3
-diableavionics_raven_wing_independent,diableavionics_raven_Standard,"restricted, independent_of_carrier, auto_fighter, no_drop, no_sell, fighter4, fighter, high, rd_no_extra_craft",4,2,12,1,BOX,4000,500,,1,FIGHTER,Heavy Trooper,20,13000,,,,,,,,,,,,,1
-diableavionics_zephyr_wing_independent,diableavionics_zephyr_beam,"restricted, independent_of_carrier, auto_fighter, no_drop, no_sell, fighter4, fighter, high, rd_no_extra_craft",4,2,8,1,BOX,4000,500,,1,FIGHTER,Support,18,14000,,,,,,,,,,,,,1
+diableavionics_frost_wing_independent,diableavionics_frost_Standard,"restricted, hide_in_codex, independent_of_carrier, auto_fighter, no_drop, no_sell, fighter1, fighter, high, rd_no_extra_craft",4,2,6,1,CLAW,4000,500,,3,FIGHTER,Trooper,12,10000,,,,,,,,,,,,,1
+diableavionics_strife_wing_independent,diableavionics_strife_Standard,"restricted, hide_in_codex, independent_of_carrier, auto_fighter, no_drop, no_sell, fighter2, fighter, high, rd_no_extra_craft",4,2,7,1,BOX,4000,500,-100,2,FIGHTER,Gunner,14,11000,,,,,,,,,,,,,4
+diableavionics_hoar_wing_independent,diableavionics_hoar_akimbo,"restricted, hide_in_codex, independent_of_carrier, auto_fighter, no_drop, no_sell, fighter3, fighter, high, rd_no_extra_craft",4,2,7,1,BOX,1000,500,200,2,INTERCEPTOR,Bodyguard,13,11500,,,,,,,,,,,,,4
+diableavionics_warlust_wing_independent,diableavionics_warlust_Standard,"restricted, hide_in_codex, independent_of_carrier, auto_fighter, no_drop, no_sell, fighter3, fighter, high, rd_no_extra_craft",4,2,6,1,BOX,1000,500,,1,SUPPORT,Sniper,17,12000,,,,,,,,,,,,,5
+diableavionics_blizzaia_wing_independent,diableavionics_blizzaia_Standard,"restricted, hide_in_codex, independent_of_carrier, auto_fighter, no_drop, no_sell, bomber5, bomber, high, rd_no_extra_craft",4,2,11,1,V,4000,1000,-200,1,BOMBER,Grenadier,19,14000,,,,,,,,,,,,,13
+diableavionics_avalanche_wing_independent,diableavionics_avalanche_variant,"restricted, hide_in_codex, independent_of_carrier, auto_fighter, no_drop, no_sell, fighter3, fighter, high, rd_no_extra_craft",4,2,6,1,BOX,4000,500,,1,FIGHTER,Shock Trooper,15,12000,,,,,,,,,,,,,5
+diableavionics_valiant_wing_independent,diableavionics_valiant_Standard,"restricted, hide_in_codex, independent_of_carrier, auto_fighter, no_drop, no_sell, interceptor3, interceptor, high, rd_no_extra_craft",4,2,10,1,V,6000,500,-100,2,INTERCEPTOR,Commando,16,15000,,,,,,,,,,,,,3
+diableavionics_raven_wing_independent,diableavionics_raven_Standard,"restricted, hide_in_codex, independent_of_carrier, auto_fighter, no_drop, no_sell, fighter4, fighter, high, rd_no_extra_craft",4,2,12,1,BOX,4000,500,,1,FIGHTER,Heavy Trooper,20,13000,,,,,,,,,,,,,1
+diableavionics_zephyr_wing_independent,diableavionics_zephyr_beam,"restricted, hide_in_codex, independent_of_carrier, auto_fighter, no_drop, no_sell, fighter4, fighter, high, rd_no_extra_craft",4,2,8,1,BOX,4000,500,,1,FIGHTER,Support,18,14000,,,,,,,,,,,,,1

--- a/src/data/hullmods/DiableAvionicsMountBI.java
+++ b/src/data/hullmods/DiableAvionicsMountBI.java
@@ -81,7 +81,7 @@ public class DiableAvionicsMountBI extends BaseHullMod {
             return RANGE_BOOST + " " + txt("su");
         }
         if (index == 1) {
-            return 25 + txt("%");
+            return (int)(-RECOIL_REDUCTION) + txt("%");
         }
         if (index == 2) {
             return LARGE_MOUNT_EXTRA_RANGE_BOOST + " " + txt("su");

--- a/src/data/hullmods/DiableAvionicsSniperkit.java
+++ b/src/data/hullmods/DiableAvionicsSniperkit.java
@@ -18,7 +18,7 @@ public class DiableAvionicsSniperkit extends BaseHullMod {
     private float REDUCED_RANGE =0.25f;
     private float SMOD_REDUCED_RANGE=0.75f;
 
-    public static Map mag = new HashMap();
+    public static Map<ShipAPI.HullSize, Float> mag = new HashMap<ShipAPI.HullSize, Float>();
     static {
         mag.put(ShipAPI.HullSize.FRIGATE, 10f);
         mag.put(ShipAPI.HullSize.DESTROYER, 20f);
@@ -36,16 +36,14 @@ public class DiableAvionicsSniperkit extends BaseHullMod {
                 continue;
             }
             if(stats.getVariant().getWingId(i).equals("diableavionics_warlust_wing")){
-               if(sMod){
-                   stats.getFighterWingRange().modifyMult(id, 0.25f);
-               }else{
-                   stats.getFighterWingRange().modifyMult(id, 0f);
-               }
+                if(sMod){
+                    stats.getFighterWingRange().modifyMult(id, SMOD_REDUCED_RANGE);
+                }else{
+                    stats.getFighterWingRange().modifyMult(id, REDUCED_RANGE);
+                }
             }
         }
-
     }
-
 
     @Override
     public void applyEffectsToFighterSpawnedByShip(ShipAPI fighter, ShipAPI ship, String id) {
@@ -54,13 +52,11 @@ public class DiableAvionicsSniperkit extends BaseHullMod {
             if(fighter.getWing().getWingId().equals("diableavionics_warlust_wing"))
             {
                 fighter.addTag(Tags.WING_STAY_IN_FRONT_OF_SHIP);
-                fighter.getMutableStats().getBallisticWeaponRangeBonus().modifyPercent(id,(Float)mag.get(ship.getHullSize()));
+                fighter.getMutableStats().getBallisticWeaponRangeBonus().modifyPercent(id, mag.get(ship.getHullSize()));
 //                List<WeaponAPI> Allweapon= fighter.getWingLeader().getAllWeapons();
 //                for(WeaponAPI w:Allweapon){
 //                    Global.getLogger(this.getClass()).info(w.getRange());
 //                }         used by debug
-
-                // fighter.addTag(Tags.WING_STAY_IN_FRONT_OF_SHIP);
             }
         }
     }
@@ -73,10 +69,10 @@ public class DiableAvionicsSniperkit extends BaseHullMod {
     }
 
     public String getDescriptionParam(int index, ShipAPI.HullSize hullSize) {
-        if (index == 0) return "" + ((Float) mag.get(ShipAPI.HullSize.FRIGATE)).intValue() + "%";
-        if (index == 1) return "" + ((Float) mag.get(ShipAPI.HullSize.DESTROYER)).intValue() + "%";
-        if (index == 2) return "" + ((Float) mag.get(ShipAPI.HullSize.CRUISER)).intValue() + "%";
-        if (index == 3) return "" + ((Float) mag.get(ShipAPI.HullSize.CAPITAL_SHIP)).intValue() + "%";
+        if (index == 0) return "" + (mag.get(ShipAPI.HullSize.FRIGATE)).intValue() + "%";
+        if (index == 1) return "" + (mag.get(ShipAPI.HullSize.DESTROYER)).intValue() + "%";
+        if (index == 2) return "" + (mag.get(ShipAPI.HullSize.CRUISER)).intValue() + "%";
+        if (index == 3) return "" + (mag.get(ShipAPI.HullSize.CAPITAL_SHIP)).intValue() + "%";
         if (index == 4) return "" + (int)((1-REDUCED_RANGE)*100)+ "%";
         return null;
     }


### PR DESCRIPTION
Update the Sniper Kit hullmod to match it's description

Clarified the wording on the Sniper Kit's description, and updated the
hullmod to work as expected. It's possible that this is supposed to be
the other way around, and the description needs to be updated. But
S-Modding for a `0.25` mult on engagement range doesn't seem right either.

While looking at things:
- updated the attack run range on the Warlust's to be 1000 to
 better match it's weapon distances. 
- added the `hide_in_codex` tag to the `_independent` wings to reduce
duplicate entries in the codex
- Correct the description of Damped Mounts, use the actual
 `RECOIL_REDUCTION` variable rather than the hardcoded (and incorrect) `25`